### PR TITLE
chore(theme-tokens): add shadcn border, input, ring, and semantic color tokens

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,35 @@ module.exports = {
           'dark-card': '#1A1530',
           'dark-border': '#2D2550',
         },
+        border: 'var(--border)',
+        input: 'var(--input)',
+        ring: 'var(--ring)',
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        primary: {
+          DEFAULT: 'var(--primary)',
+          foreground: 'var(--primary-foreground)',
+        },
+        secondary: {
+          DEFAULT: 'var(--secondary)',
+          foreground: 'var(--secondary-foreground)',
+        },
+        muted: {
+          DEFAULT: 'var(--muted)',
+          foreground: 'var(--muted-foreground)',
+        },
+        accent: {
+          DEFAULT: 'var(--accent)',
+          foreground: 'var(--accent-foreground)',
+        },
+        destructive: {
+          DEFAULT: 'var(--destructive)',
+          foreground: 'var(--destructive-foreground)',
+        },
+        popover: 'var(--popover)',
+        'popover-foreground': 'var(--popover-foreground)',
+        card: 'var(--card)',
+        'card-foreground': 'var(--card-foreground)',
       },
       fontFamily: {
         sans: ['Poppins', ...defaultTheme.fontFamily.sans],


### PR DESCRIPTION

This PR updates the Tailwind configuration to support shadcn/ui theme tokens by introducing semantic color variables for borders, inputs, rings, backgrounds, cards, popovers, and component states.

The change enables proper styling and theming of shadcn/ui components while preserving the existing custom design system.

## Changes Made

### Added Theme Tokens

- `border`
- `input`
- `ring`
- `background`
- `foreground`

### Added Semantic Color Groups

- `primary`
- `secondary`
- `muted`
- `accent`
- `destructive`

### Added Component Tokens

- `popover`
- `popover-foreground`
- `card`
- `card-foreground`

### Preserved Existing Configuration

- Brand color palette
- Custom fonts
- Background gradients
- Shadows
- Animations
- Keyframes

## Why This Change?

shadcn/ui components depend on semantic design tokens rather than hardcoded colors.

Adding these tokens:

- Improves component consistency.
- Enables easier theme customization.
- Supports future dark mode implementation.
- Ensures compatibility with generated shadcn components.
- Allows Tailwind border and ring utilities to work correctly.

## Testing

- Verified Tailwind compiles successfully.
- Confirmed border utilities resolve correctly.
- Confirmed ring utilities render correctly.
- Tested compatibility with shadcn components.
- Verified existing brand styling remains unchanged.
- Confirmed no breaking changes to custom animations or shadows.

## Type of Change

- [x] Chore
- [ ] Bug Fix
- [ ] Feature
- [ ] Breaking Change

## Expected Outcome

The application now supports shadcn/ui semantic theme tokens, allowing reusable components to inherit consistent styling and making future design-system enhancements easier to implement.

Closes #63 #64 